### PR TITLE
Add TCP keepalive to sockets to prevent dead connections

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "pretty-quick": "^1.3.0"
   },
   "dependencies": {
-    "socket-pool": "^1.2.1"
+    "socket-pool": "^1.2.1",
+    "net-keepalive": "^1.2.1"
   }
 }

--- a/src/SomfySynergy.js
+++ b/src/SomfySynergy.js
@@ -4,6 +4,8 @@ const SomfySynergyPlatform = require('./SomfySynergyPlatform');
 
 const {default: SocketPool} = require('socket-pool');
 
+const NetKeepAlive = require('net-keepalive');
+
 class SomfySynergy {
   constructor(systemID, host, port = 44100) {
     this._nextID = 1;
@@ -27,6 +29,7 @@ class SomfySynergy {
     return this._socketPool.acquire().then(
       socket =>
         new Promise((resolve, reject) => {
+          socket._socket.setKeepAlive(true, 5000);
           socket.write(JSON.stringify(request), error => {
             if (error != null) {
               reject(error);


### PR DESCRIPTION
So when I first started using https://github.com/yungsters/homebridge-mylink , it would work fine at first, but then a few hours later when I tried to issue the next command, it would crash with an `ECONNRESET` error:

```
2019-01-05_23:08:53.10278 [1/5/2019, 6:08:53 PM] [Somfy myLink] Setting position of target AAAA100E.5 (Living Room) from 50% to 100%.
2019-01-05_23:08:53.60924 events.js:167
2019-01-05_23:08:53.60928       throw er; // Unhandled 'error' event
2019-01-05_23:08:53.60929       ^
2019-01-05_23:08:53.60929 
2019-01-05_23:08:53.60930 Error: read ECONNRESET
2019-01-05_23:08:53.60931     at TCP.onStreamRead (internal/stream_base_commons.js:111:27)
2019-01-05_23:08:53.60932 Emitted 'error' event at:
2019-01-05_23:08:53.60932     at emitErrorNT (internal/streams/destroy.js:82:8)
2019-01-05_23:08:53.60933     at emitErrorAndCloseNT (internal/streams/destroy.js:50:3)
2019-01-05_23:08:53.60934     at process._tickCallback (internal/process/next_tick.js:63:19)
```

With a bit of digging, I figured out what was going on: Homebridge was maintaining a persistent link to the MyLink, and eventually, either the MyLink would reboot, or otherwise forget about the connection.  (I used to have issues with the MyLink becoming unresponsive after a week or so, so at some point, they probably introduced regular reboots to avoid that.)

Homebridge crashing isn't ideal, but it's also not a huge deal — I've got it set to auto-restart anyway.  The bigger problem is that it wouldn't detect this situation and crash until _the next_ command was issued — which is the worst time to crash, since it means that command just gets lost completely.

I want to implement a more complete solution, but for now, this small patch gets things working mostly-properly again:

* We now send a 0-byte TCP keepalive to the MyLink on a regular basis — the exact schedule is configured by the OS, since I don't change the defaults, but it seems to be about every minute on my Linux system.
* Most TCP services would just respond with a 0-byte TCP `ACK` (acknowledge) — oddly, the MyLink actually seems to understand keepalives and sends back `{"method":"mylink.status.keepalive"}`, but that doesn't seem to interfere with anything.
* The connection is still reset (a few hours later), and Homebridge still crashes — but it does so at an arbitrary time, rather than "right as I issue the next command", so I've not lost a single command so far.

At some point I want to go deeper and set up proper `ECONNRESET` handling in `socket-pool`, as well as maybe an option to close connections if they're idle too long, and maybe move the keepalive option to `socket-pool` as well.  But I'm not much of a Node/JS programmer yet, so this seemed like an easy win to start.