### PR TITLE
Clear pending requests after they are processed

### DIFF
--- a/src/SomfySynergyPlatform.js
+++ b/src/SomfySynergyPlatform.js
@@ -69,6 +69,7 @@ class SomfySynergyPlatform {
       }
       requestsByMethod.get(method).set(targetID, {resolve, reject});
     }
+    this._pendingRequests.clear();
 
     for (const [method, requests] of requestsByMethod) {
       const reducedRequests = this._reduceRequests(requests);


### PR DESCRIPTION
The current synergy platform retains each record in the `_pendingRequets` map.  This leads to issues when you have multiple targets, and are only trying to control one of them.  For example if I close Target A and Target B with HomeKit, then open Target A with a remote (not through code).  When I open Target B with HomeKit, SomfySynergy still thinks that Target A should be closed and will _resend_ the command to MyLink to close it.